### PR TITLE
main関数を削除して外にStatementをかけるようにする

### DIFF
--- a/inc/parser.hpp
+++ b/inc/parser.hpp
@@ -42,8 +42,8 @@ typedef class Parser{
 		  */
 		bool visitTranslationUnit();
 		bool visitExternalDeclaration(TranslationUnitAST *tunit);
-		PrototypeAST *visitFunctionDeclaration();
 		FunctionAST *visitFunctionDefinition();
+		FunctionAST *visitExternalStatement();
 		PrototypeAST *visitPrototype();
 		FunctionStmtAST *visitFunctionStatement(PrototypeAST *proto);
 		VariableDeclAST *visitVariableDeclaration();

--- a/sample/test.dp
+++ b/sample/test.dp
@@ -7,8 +7,6 @@ int test(int j)
 
 
 
-int main()
-	int i;
-	i=10*2;i=10
-	printnum(test(i))
-	return 0
+int i;
+i=10*2;i=10
+printnum(test(i))

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -73,7 +73,10 @@ bool CodeGen::generateTranslationUnit(TranslationUnitAST &tunit, std::string nam
 			SAFE_DELETE(Mod);
 			return false;
 		}
+		if(func->getName() == "main")Builder->CreateRet(Builder->getInt32(0));
 	}
+
+
 
 	return true;
 }


### PR DESCRIPTION
- main関数がなく、インデントレベル０でかけるようにする
    - FunctionDeclarationをParseしていた部分でFunctionStatementのようなExternalStatementをParseする
    - return文は関数の外では認めない
        - 構文的には外にあるMain関数にするのでcodegenでret i32 0を最後に挿入する