### PR TITLE
変数宣言の削除

### DIFF
--- a/sample/test.dp
+++ b/sample/test.dp
@@ -1,5 +1,4 @@
 int test(int j)
-	int i
 	i=j*10
 	return i
 
@@ -7,6 +6,5 @@ int test(int j)
 
 
 
-int i;
 i=10*2;i=10
 printnum(test(i))


### PR DESCRIPTION
- intから始まる宣言をなくす
    - Statementで変数の宣言をParseするのをやめ、初回の代入時にIdentifierを登録し、宣言ASTを作る
